### PR TITLE
Update package.json

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -49,7 +49,7 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/user-event": "^14.6.1",
         "@types/webpack-env": "^1.16",
-        "@vitejs/plugin-vue": "^4.4.0",
+        "@vitejs/plugin-vue": "^5.1.5",
         "jsdom": "^26.1.0",
         "tslib": "^2.8.1",
         "tsx": "^4.20.3",


### PR DESCRIPTION
esbuild 0.21.5 require by vite 5.4.19, require by plugin-vue 4.6.2  contain security vulnerabilities 

It's necessary to upgrade to esbquild 0.25.0+, so plugin-vue must be in 5.1.5+ in order to have vite 6+